### PR TITLE
feat: add theme toggle and color variables

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,5 +1,6 @@
 import { Component, signal } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { ThemeService } from './services/theme-service';
 
 @Component({
   selector: 'app-root',
@@ -9,4 +10,6 @@ import { RouterOutlet } from '@angular/router';
 })
 export class App {
   protected readonly title = signal('admin-panel');
+
+  constructor(private themeService: ThemeService) {}
 }

--- a/src/app/components/layout-component/layout-component.html
+++ b/src/app/components/layout-component/layout-component.html
@@ -1,5 +1,5 @@
-<div class="flex h-screen bg-slate-100">
-  <aside class="flex flex-col items-center w-20 py-8 space-y-8 bg-white shadow-md">
+<div class="flex h-screen bg-[var(--bg-color)]">
+  <aside class="flex flex-col items-center w-20 py-8 space-y-8 bg-[var(--card-bg)] shadow-md">
     <!-- Logo -->
     <a routerLink="/dashboard" class="p-2 text-white rounded-lg bg-primary">
       <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -14,7 +14,7 @@
         <a routerLink="/dashboard" 
            routerLinkActive="bg-primary text-white" 
            [routerLinkActiveOptions]="{exact: true}"
-           class="flex items-center justify-center w-12 h-12 text-gray-500 rounded-xl hover:bg-primary hover:text-white transition-colors duration-200">
+           class="flex items-center justify-center w-12 h-12 text-[var(--text-color)] rounded-xl hover:bg-primary hover:text-white transition-colors duration-200">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" /></svg>
         </a>
         <div class="absolute left-full ml-2 px-2 py-1 text-sm text-white bg-gray-800 rounded-md opacity-0 group-hover:opacity-100 transition-opacity duration-200 whitespace-nowrap -translate-y-1/2 top-1/2">
@@ -26,7 +26,7 @@
       <div class="relative group">
         <a routerLink="/services" 
            routerLinkActive="bg-primary text-white"
-           class="flex items-center justify-center w-12 h-12 text-gray-500 rounded-xl hover:bg-primary hover:text-white transition-colors duration-200">
+           class="flex items-center justify-center w-12 h-12 text-[var(--text-color)] rounded-xl hover:bg-primary hover:text-white transition-colors duration-200">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A2 2 0 013 12V7a4 4 0 014-4z" /></svg>
         </a>
         <div class="absolute left-full ml-2 px-2 py-1 text-sm text-white bg-gray-800 rounded-md opacity-0 group-hover:opacity-100 transition-opacity duration-200 whitespace-nowrap -translate-y-1/2 top-1/2">
@@ -38,7 +38,7 @@
       <div class="relative group">
         <a routerLink="/clients" 
            routerLinkActive="bg-primary text-white"
-           class="flex items-center justify-center w-12 h-12 text-gray-500 rounded-xl hover:bg-primary hover:text-white transition-colors duration-200">
+           class="flex items-center justify-center w-12 h-12 text-[var(--text-color)] rounded-xl hover:bg-primary hover:text-white transition-colors duration-200">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.653-.124-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.653.124-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
           </svg>
@@ -51,7 +51,7 @@
       <div class="relative group">
         <a routerLink="/agenda" 
           routerLinkActive="bg-primary text-white"
-          class="flex items-center justify-center w-12 h-12 text-gray-500 rounded-xl hover:bg-primary hover:text-white transition-colors duration-200">
+          class="flex items-center justify-center w-12 h-12 text-[var(--text-color)] rounded-xl hover:bg-primary hover:text-white transition-colors duration-200">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
           </svg>
@@ -67,7 +67,7 @@
       <div class="relative group">
         <a routerLink="/settings"
            routerLinkActive="bg-primary text-white"
-           class="flex items-center justify-center w-12 h-12 text-gray-500 rounded-xl hover:bg-primary hover:text-white transition-colors duration-200">
+           class="flex items-center justify-center w-12 h-12 text-[var(--text-color)] rounded-xl hover:bg-primary hover:text-white transition-colors duration-200">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.096 2.572-1.065z" />
             <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
@@ -79,8 +79,20 @@
       </div>
 
       <div class="relative group">
+        <button (click)="toggleTheme()"
+                class="flex items-center justify-center w-12 h-12 text-[var(--text-color)] rounded-xl hover:bg-primary hover:text-white transition-colors duration-200">
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m8-9h1M3 12H2m15.364-6.364l.707.707M6.343 17.657l-.707.707m0-12.728l.707.707M17.657 17.657l.707.707M12 8a4 4 0 100 8 4 4 0 000-8z" />
+          </svg>
+        </button>
+        <div class="absolute left-full ml-2 px-2 py-1 text-sm text-white bg-gray-800 rounded-md opacity-0 group-hover:opacity-100 transition-opacity duration-200 whitespace-nowrap -translate-y-1/2 top-1/2">
+          Cambiar tema
+        </div>
+      </div>
+
+      <div class="relative group">
         <button (click)="logout()"
-                class="flex items-center justify-center w-12 h-12 text-gray-500 rounded-xl hover:bg-red-500 hover:text-white transition-colors duration-200">
+                class="flex items-center justify-center w-12 h-12 text-[var(--text-color)] rounded-xl hover:bg-red-500 hover:text-white transition-colors duration-200">
           <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"></path></svg>
         </button>
         <div class="absolute left-full ml-2 px-2 py-1 text-sm text-white bg-gray-800 rounded-md opacity-0 group-hover:opacity-100 transition-opacity duration-200 whitespace-nowrap -translate-y-1/2 top-1/2">

--- a/src/app/components/layout-component/layout-component.ts
+++ b/src/app/components/layout-component/layout-component.ts
@@ -4,6 +4,7 @@ import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 import { ToastContainerComponent } from '../toast-container-component/toast-container-component';
 import { AuthService } from '../../services/auth-service';
 import { Router } from '@angular/router';
+import { ThemeService } from '../../services/theme-service';
 
 @Component({
   selector: 'app-layout',
@@ -15,12 +16,17 @@ import { Router } from '@angular/router';
 export class LayoutComponent {
   constructor(
     private authService: AuthService,
-    private router: Router
+    private router: Router,
+    private themeService: ThemeService
   ) {}
 
   logout() {
     this.authService.logout()
       .then(() => this.router.navigate(['/login']))
       .catch(error => console.error(error));
-  } 
+  }
+
+  toggleTheme() {
+    this.themeService.toggleTheme();
+  }
 }

--- a/src/app/services/theme-service.ts
+++ b/src/app/services/theme-service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ThemeService {
+  private readonly storageKey = 'theme';
+  private currentTheme: 'light' | 'dark' = 'light';
+
+  constructor() {
+    const stored = localStorage.getItem(this.storageKey) as 'light' | 'dark' | null;
+    if (stored) {
+      this.currentTheme = stored;
+    }
+    this.applyTheme(this.currentTheme);
+  }
+
+  toggleTheme(): void {
+    this.currentTheme = this.currentTheme === 'light' ? 'dark' : 'light';
+    this.applyTheme(this.currentTheme);
+  }
+
+  get theme(): 'light' | 'dark' {
+    return this.currentTheme;
+  }
+
+  private applyTheme(theme: 'light' | 'dark'): void {
+    const html = document.documentElement;
+    html.classList.remove('light-theme', 'dark-theme');
+    html.classList.add(`${theme}-theme`);
+    localStorage.setItem(this.storageKey, theme);
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -6,3 +6,36 @@
 :root {
   --color-primary: 243 92% 62%; /* Este es un color HSL azul/púrpura similar al de la imagen */
 }
+
+.light-theme {
+  --bg-color: #f8fafc;
+  --text-color: #1f2937;
+  --card-bg: #ffffff;
+  --table-bg: #ffffff;
+  --calendar-bg: #ffffff;
+}
+
+.dark-theme {
+  --bg-color: #1f2937;
+  --text-color: #f8fafc;
+  --card-bg: #111827;
+  --table-bg: #1f2937;
+  --calendar-bg: #1f2937;
+}
+
+body {
+  background-color: var(--bg-color);
+  color: var(--text-color);
+}
+
+table {
+  background-color: var(--table-bg);
+  color: var(--text-color);
+}
+
+.cal-week-view,
+.cal-day-headers,
+.cal-hour-rows {
+  background-color: var(--calendar-bg) !important;
+  color: var(--text-color) !important;
+}


### PR DESCRIPTION
## Summary
- add light/dark theme variables and global styles
- implement ThemeService to store theme preference and toggle
- add theme switch button and apply theme class

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689fe0c971e48327a050a9b92e211801