### PR TITLE
feat: improve form accessibility and validation

### DIFF
--- a/src/app/components/appointment-form-component/appointment-form-component.html
+++ b/src/app/components/appointment-form-component/appointment-form-component.html
@@ -11,31 +11,51 @@
       
       <div>
         <label for="client" class="text-sm font-medium text-gray-700">Cliente</label>
-          <select id="client" formControlName="clientId" class="w-full px-4 py-3 mt-1 text-gray-700 bg-gray-100 border rounded-lg">
+          <select id="client" formControlName="clientId" class="w-full px-4 py-3 mt-1 text-gray-700 bg-gray-100 border rounded-lg"
+                  [attr.aria-invalid]="appointmentForm.get('clientId')?.invalid && appointmentForm.get('clientId')?.touched"
+                  [attr.aria-describedby]="appointmentForm.get('clientId')?.invalid && appointmentForm.get('clientId')?.touched ? 'client-error' : null">
           <option value="" disabled>Selecciona un cliente...</option>
           <option *ngFor="let client of clients$ | async" [value]="client.id">{{ client.name }}</option>
         </select>
+        <div id="client-error" *ngIf="appointmentForm.get('clientId')?.invalid && appointmentForm.get('clientId')?.touched" class="mt-1 text-sm text-red-600">
+          El cliente es obligatorio.
+        </div>
       </div>
       <div>
         <label for="service" class="text-sm font-medium text-gray-700">Servicio</label>
-          <select id="service" formControlName="serviceId" class="w-full px-4 py-3 mt-1 text-gray-700 bg-gray-100 border rounded-lg">
+          <select id="service" formControlName="serviceId" class="w-full px-4 py-3 mt-1 text-gray-700 bg-gray-100 border rounded-lg"
+                  [attr.aria-invalid]="appointmentForm.get('serviceId')?.invalid && appointmentForm.get('serviceId')?.touched"
+                  [attr.aria-describedby]="appointmentForm.get('serviceId')?.invalid && appointmentForm.get('serviceId')?.touched ? 'service-error' : null">
           <option value="" disabled>Selecciona un servicio...</option>
           <option *ngFor="let service of services$ | async" [value]="service.id">{{ service.name }} ({{ service.duration }} min)</option>
         </select>
+        <div id="service-error" *ngIf="appointmentForm.get('serviceId')?.invalid && appointmentForm.get('serviceId')?.touched" class="mt-1 text-sm text-red-600">
+          El servicio es obligatorio.
+        </div>
       </div>
 
       <div>
         <label for="status" class="text-sm font-medium text-gray-700">Estado de la Cita</label>
-          <select id="status" formControlName="status" class="w-full px-4 py-3 mt-1 text-gray-700 bg-gray-100 border rounded-lg">
+          <select id="status" formControlName="status" class="w-full px-4 py-3 mt-1 text-gray-700 bg-gray-100 border rounded-lg"
+                  [attr.aria-invalid]="appointmentForm.get('status')?.invalid && appointmentForm.get('status')?.touched"
+                  [attr.aria-describedby]="appointmentForm.get('status')?.invalid && appointmentForm.get('status')?.touched ? 'status-error' : null">
           <option value="confirmed">Confirmado / Agendado</option>
           <option value="pending">En Espera / Por Aprobar</option>
           <option value="cancelled">Rechazado / Cancelado</option>
         </select>
+        <div id="status-error" *ngIf="appointmentForm.get('status')?.invalid && appointmentForm.get('status')?.touched" class="mt-1 text-sm text-red-600">
+          El estado es obligatorio.
+        </div>
       </div>
 
       <div class="pt-4 border-t">
         <label for="start" class="text-sm font-medium text-gray-700">Fecha y Hora de Inicio</label>
-          <input id="start" type="datetime-local" formControlName="start" class="w-full px-4 py-3 mt-1 text-gray-700 bg-gray-100 border rounded-lg">
+          <input id="start" type="datetime-local" formControlName="start" class="w-full px-4 py-3 mt-1 text-gray-700 bg-gray-100 border rounded-lg"
+                 [attr.aria-invalid]="appointmentForm.get('start')?.invalid && appointmentForm.get('start')?.touched"
+                 [attr.aria-describedby]="appointmentForm.get('start')?.invalid && appointmentForm.get('start')?.touched ? 'start-error' : null">
+        <div id="start-error" *ngIf="appointmentForm.get('start')?.invalid && appointmentForm.get('start')?.touched" class="mt-1 text-sm text-red-600">
+          La fecha y hora de inicio son obligatorias.
+        </div>
       </div>
 
       <div>
@@ -100,3 +120,4 @@
   (onConfirm)="confirmDelete()"
   (onCancel)="cancelDelete()">
 </app-confirmation-dialog>
+

--- a/src/app/components/appointment-form-component/appointment-form-component.ts
+++ b/src/app/components/appointment-form-component/appointment-form-component.ts
@@ -148,3 +148,4 @@ export class AppointmentFormComponent implements OnInit, OnChanges {
     this.onCancel.emit();
   }
 }
+

--- a/src/app/components/client-form-component/client-form-component.html
+++ b/src/app/components/client-form-component/client-form-component.html
@@ -12,19 +12,34 @@
       <div>
         <label for="name" class="text-sm font-medium text-gray-700">Nombre Completo</label>
           <input id="name" type="text" formControlName="name" placeholder="Ej: Ana Contreras"
-                 class="w-full px-4 py-3 mt-1 text-gray-700 bg-gray-100 border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary">
+                 class="w-full px-4 py-3 mt-1 text-gray-700 bg-gray-100 border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
+                 [attr.aria-invalid]="clientForm.get('name')?.invalid && clientForm.get('name')?.touched"
+                 [attr.aria-describedby]="clientForm.get('name')?.invalid && clientForm.get('name')?.touched ? 'name-error' : null">
+        <div id="name-error" *ngIf="clientForm.get('name')?.invalid && clientForm.get('name')?.touched" class="mt-1 text-sm text-red-600">
+          El nombre es obligatorio.
+        </div>
       </div>
 
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div>
           <label for="email" class="text-sm font-medium text-gray-700">Correo Electrónico</label>
             <input id="email" type="email" formControlName="email" placeholder="ejemplo@correo.com"
-                   class="w-full px-4 py-3 mt-1 text-gray-700 bg-gray-100 border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary">
+                   class="w-full px-4 py-3 mt-1 text-gray-700 bg-gray-100 border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
+                   [attr.aria-invalid]="clientForm.get('email')?.invalid && clientForm.get('email')?.touched"
+                   [attr.aria-describedby]="clientForm.get('email')?.invalid && clientForm.get('email')?.touched ? 'email-error' : null">
+          <div id="email-error" *ngIf="clientForm.get('email')?.invalid && clientForm.get('email')?.touched" class="mt-1 text-sm text-red-600">
+            {{ clientForm.get('email')?.errors?.['email'] ? 'Ingresa un correo válido.' : 'El correo es obligatorio.' }}
+          </div>
         </div>
         <div>
           <label for="phone" class="text-sm font-medium text-gray-700">Teléfono</label>
             <input id="phone" type="tel" formControlName="phone" placeholder="+56 9 1234 5678"
-                   class="w-full px-4 py-3 mt-1 text-gray-700 bg-gray-100 border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary">
+                   class="w-full px-4 py-3 mt-1 text-gray-700 bg-gray-100 border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
+                   [attr.aria-invalid]="clientForm.get('phone')?.invalid && clientForm.get('phone')?.touched"
+                   [attr.aria-describedby]="clientForm.get('phone')?.invalid && clientForm.get('phone')?.touched ? 'phone-error' : null">
+          <div id="phone-error" *ngIf="clientForm.get('phone')?.invalid && clientForm.get('phone')?.touched" class="mt-1 text-sm text-red-600">
+            El teléfono es obligatorio.
+          </div>
         </div>
       </div>
 
@@ -43,10 +58,12 @@
                 [ngClass]="{
                   'bg-primary hover:bg-opacity-90': clientForm.valid,
                   'bg-gray-400 cursor-not-allowed': !clientForm.valid
-                }">
+                }"
+                [disabled]="clientForm.invalid">
           Guardar Cliente
         </button>
       </div>
     </form>
   </div>
 </div>
+

--- a/src/app/components/client-form-component/client-form-component.ts
+++ b/src/app/components/client-form-component/client-form-component.ts
@@ -32,13 +32,16 @@ export class ClientFormComponent implements OnInit {
   }
 
   save(): void {
-    if (this.clientForm.valid) {
-      const formData = { ...this.client, ...this.clientForm.value };
-      this.onSave.emit(formData);
+    if (this.clientForm.invalid) {
+      this.clientForm.markAllAsTouched();
+      return;
     }
+    const formData = { ...this.client, ...this.clientForm.value };
+    this.onSave.emit(formData);
   }
 
   cancel(): void {
     this.onCancel.emit();
   }
 }
+

--- a/src/app/components/service-form-component/service-form-component.html
+++ b/src/app/components/service-form-component/service-form-component.html
@@ -12,19 +12,34 @@
       <div>
         <label for="name" class="text-sm font-medium text-gray-700">Nombre del Servicio</label>
           <input id="name" type="text" formControlName="name" placeholder="Ej: Consulta Inicial"
-                 class="w-full px-4 py-3 mt-1 text-gray-700 bg-gray-100 border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary">
+                 class="w-full px-4 py-3 mt-1 text-gray-700 bg-gray-100 border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
+                 [attr.aria-invalid]="serviceForm.get('name')?.invalid && serviceForm.get('name')?.touched"
+                 [attr.aria-describedby]="serviceForm.get('name')?.invalid && serviceForm.get('name')?.touched ? 'service-name-error' : null">
+        <div id="service-name-error" *ngIf="serviceForm.get('name')?.invalid && serviceForm.get('name')?.touched" class="mt-1 text-sm text-red-600">
+          El nombre es obligatorio.
+        </div>
       </div>
 
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div>
           <label for="duration" class="text-sm font-medium text-gray-700">Duración (min)</label>
             <input id="duration" type="number" formControlName="duration"
-                   class="w-full px-4 py-3 mt-1 text-gray-700 bg-gray-100 border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary">
+                   class="w-full px-4 py-3 mt-1 text-gray-700 bg-gray-100 border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
+                   [attr.aria-invalid]="serviceForm.get('duration')?.invalid && serviceForm.get('duration')?.touched"
+                   [attr.aria-describedby]="serviceForm.get('duration')?.invalid && serviceForm.get('duration')?.touched ? 'duration-error' : null">
+          <div id="duration-error" *ngIf="serviceForm.get('duration')?.invalid && serviceForm.get('duration')?.touched" class="mt-1 text-sm text-red-600">
+            {{ serviceForm.get('duration')?.errors?.['min'] ? 'Debe ser mayor o igual a 1.' : 'La duración es obligatoria.' }}
+          </div>
         </div>
         <div>
           <label for="price" class="text-sm font-medium text-gray-700">Precio</label>
             <input id="price" type="number" formControlName="price"
-                   class="w-full px-4 py-3 mt-1 text-gray-700 bg-gray-100 border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary">
+                   class="w-full px-4 py-3 mt-1 text-gray-700 bg-gray-100 border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
+                   [attr.aria-invalid]="serviceForm.get('price')?.invalid && serviceForm.get('price')?.touched"
+                   [attr.aria-describedby]="serviceForm.get('price')?.invalid && serviceForm.get('price')?.touched ? 'price-error' : null">
+          <div id="price-error" *ngIf="serviceForm.get('price')?.invalid && serviceForm.get('price')?.touched" class="mt-1 text-sm text-red-600">
+            {{ serviceForm.get('price')?.errors?.['min'] ? 'Debe ser mayor o igual a 0.' : 'El precio es obligatorio.' }}
+          </div>
         </div>
       </div>
 
@@ -32,7 +47,12 @@
         <label for="bufferTime" class="text-sm font-medium text-gray-700">Tiempo Búfer (min)</label>
         <p class="text-xs text-gray-500">Tiempo extra no visible para el cliente (antes/después de la cita).</p>
           <input id="bufferTime" type="number" formControlName="bufferTime"
-                 class="w-full px-4 py-3 mt-1 text-gray-700 bg-gray-100 border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary">
+                 class="w-full px-4 py-3 mt-1 text-gray-700 bg-gray-100 border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
+                 [attr.aria-invalid]="serviceForm.get('bufferTime')?.invalid && serviceForm.get('bufferTime')?.touched"
+                 [attr.aria-describedby]="serviceForm.get('bufferTime')?.invalid && serviceForm.get('bufferTime')?.touched ? 'buffer-error' : null">
+        <div id="buffer-error" *ngIf="serviceForm.get('bufferTime')?.invalid && serviceForm.get('bufferTime')?.touched" class="mt-1 text-sm text-red-600">
+          {{ serviceForm.get('bufferTime')?.errors?.['min'] ? 'Debe ser mayor o igual a 0.' : 'El tiempo búfer es obligatorio.' }}
+        </div>
       </div>
 
       <div class="flex justify-end pt-4 space-x-4">
@@ -44,7 +64,8 @@
                 [ngClass]="{
                   'bg-primary hover:bg-opacity-90': serviceForm.valid,
                   'bg-gray-400 cursor-not-allowed': !serviceForm.valid
-                }">
+                }"
+                [disabled]="serviceForm.invalid">
           Guardar
         </button>
       </div>

--- a/src/app/components/service-form-component/service-form-component.ts
+++ b/src/app/components/service-form-component/service-form-component.ts
@@ -33,13 +33,16 @@ export class ServiceFormComponent implements OnInit {
   }
 
   save(): void {
-    if (this.serviceForm.valid) {
-      const formData = { ...this.service, ...this.serviceForm.value };
-      this.onSave.emit(formData);
+    if (this.serviceForm.invalid) {
+      this.serviceForm.markAllAsTouched();
+      return;
     }
+    const formData = { ...this.service, ...this.serviceForm.value };
+    this.onSave.emit(formData);
   }
 
   cancel(): void {
     this.onCancel.emit();
   }
 }
+


### PR DESCRIPTION
## Summary
- show field-level validation messages in appointment, client, and service forms
- add aria attributes and disable save buttons until forms are valid
- mark form controls as touched before submitting for better UX

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_689ffaf4fbc8832789244650d6e287a5