### PR TITLE
feat: improve responsive sidebar

### DIFF
--- a/src/app/components/layout-component/layout-component.html
+++ b/src/app/components/layout-component/layout-component.html
@@ -79,16 +79,20 @@
     </div>
 
     <!-- Navegación Principal -->
-    <nav class="flex flex-col items-start flex-grow space-y-2">
+    <nav
+      class="flex flex-col flex-grow"
+      [ngClass]="isSidebarCollapsed ? ['items-center', 'space-y-4'] : ['items-start', 'space-y-2']"
+    >
       <!-- Dashboard -->
       <div>
-        <a
-          routerLink="/dashboard"
-          routerLinkActive="bg-primary text-white"
-          [routerLinkActiveOptions]="{ exact: true }"
-          (click)="closeSidebar()"
-          class="nav-link flex items-center w-full h-12 px-4 text-[var(--text-color)] rounded-xl hover:bg-primary hover:text-white transition-colors duration-200"
-        >
+      <a
+        routerLink="/dashboard"
+        routerLinkActive="bg-primary text-white"
+        [routerLinkActiveOptions]="{ exact: true }"
+        (click)="closeSidebar()"
+        [attr.title]="isSidebarCollapsed ? 'Dashboard' : null"
+        class="nav-link flex items-center w-full h-12 px-4 text-[var(--text-color)] rounded-xl hover:bg-primary hover:text-white transition-colors duration-200"
+      >
           <svg
             xmlns="http://www.w3.org/2000/svg"
             class="w-6 h-6"
@@ -113,6 +117,7 @@
           routerLink="/services"
           routerLinkActive="bg-primary text-white"
           (click)="closeSidebar()"
+          [attr.title]="isSidebarCollapsed ? 'Servicios' : null"
           class="nav-link flex items-center w-full h-12 px-4 text-[var(--text-color)] rounded-xl hover:bg-primary hover:text-white transition-colors duration-200"
         >
           <svg
@@ -139,6 +144,7 @@
           routerLink="/clients"
           routerLinkActive="bg-primary text-white"
           (click)="closeSidebar()"
+          [attr.title]="isSidebarCollapsed ? 'Clientes' : null"
           class="nav-link flex items-center w-full h-12 px-4 text-[var(--text-color)] rounded-xl hover:bg-primary hover:text-white transition-colors duration-200"
         >
           <svg
@@ -165,6 +171,7 @@
           routerLink="/agenda"
           routerLinkActive="bg-primary text-white"
           (click)="closeSidebar()"
+          [attr.title]="isSidebarCollapsed ? 'Agenda' : null"
           class="nav-link flex items-center w-full h-12 px-4 text-[var(--text-color)] rounded-xl hover:bg-primary hover:text-white transition-colors duration-200"
         >
           <svg
@@ -187,12 +194,16 @@
     </nav>
 
     <!-- Navegación Inferior -->
-    <div class="flex flex-col items-start space-y-2">
+    <div
+      class="flex flex-col"
+      [ngClass]="isSidebarCollapsed ? ['items-center', 'space-y-4'] : ['items-start', 'space-y-2']"
+    >
       <div>
         <a
           routerLink="/settings"
           routerLinkActive="bg-primary text-white"
           (click)="closeSidebar()"
+          [attr.title]="isSidebarCollapsed ? 'Ajustes' : null"
           class="nav-link flex items-center w-full h-12 px-4 text-[var(--text-color)] rounded-xl hover:bg-primary hover:text-white transition-colors duration-200"
         >
           <svg
@@ -221,6 +232,7 @@
       <div>
         <button
           (click)="toggleTheme(); closeSidebar()"
+          [attr.title]="isSidebarCollapsed ? 'Cambiar tema' : null"
           class="nav-link flex items-center w-full h-12 px-4 text-[var(--text-color)] rounded-xl hover:bg-primary hover:text-white transition-colors duration-200"
         >
           <svg
@@ -244,6 +256,7 @@
       <div>
         <button
           (click)="logout(); closeSidebar()"
+          [attr.title]="isSidebarCollapsed ? 'Cerrar sesión' : null"
           class="nav-link flex items-center w-full h-12 px-4 text-[var(--text-color)] rounded-xl hover:bg-red-500 hover:text-white transition-colors duration-200"
         >
           <svg

--- a/src/app/components/layout-component/layout-component.html
+++ b/src/app/components/layout-component/layout-component.html
@@ -9,9 +9,8 @@
   ></div>
 
   <aside
-    [class.translate-x-0]="isSidebarOpen"
-    [class.collapsed]="isSidebarCollapsed"
-    class="fixed inset-y-0 left-0 z-40 flex flex-col items-start w-64 h-screen p-4 space-y-8 bg-[var(--card-bg)] shadow-md transform transition-all -translate-x-full overflow-y-auto md:relative md:translate-x-0 md:w-max md:p-4 md:overflow-y-auto md:overflow-x-hidden group"
+    [ngClass]="{ 'translate-x-0': isSidebarOpen, '-translate-x-full': !isSidebarOpen, 'collapsed': isSidebarCollapsed }"
+    class="fixed inset-y-0 left-0 z-40 flex flex-col items-start w-64 h-screen p-4 space-y-8 bg-[var(--card-bg)] shadow-md transform transition-all overflow-y-auto md:relative md:translate-x-0 md:w-64 md:p-4 md:overflow-y-auto md:overflow-x-hidden group"
   >
     <!-- Logo y controles de tamaño -->
     <div
@@ -87,6 +86,7 @@
           routerLink="/dashboard"
           routerLinkActive="bg-primary text-white"
           [routerLinkActiveOptions]="{ exact: true }"
+          (click)="closeSidebar()"
           class="nav-link flex items-center w-full h-12 px-4 text-[var(--text-color)] rounded-xl hover:bg-primary hover:text-white transition-colors duration-200"
         >
           <svg
@@ -112,6 +112,7 @@
         <a
           routerLink="/services"
           routerLinkActive="bg-primary text-white"
+          (click)="closeSidebar()"
           class="nav-link flex items-center w-full h-12 px-4 text-[var(--text-color)] rounded-xl hover:bg-primary hover:text-white transition-colors duration-200"
         >
           <svg
@@ -137,6 +138,7 @@
         <a
           routerLink="/clients"
           routerLinkActive="bg-primary text-white"
+          (click)="closeSidebar()"
           class="nav-link flex items-center w-full h-12 px-4 text-[var(--text-color)] rounded-xl hover:bg-primary hover:text-white transition-colors duration-200"
         >
           <svg
@@ -162,6 +164,7 @@
         <a
           routerLink="/agenda"
           routerLinkActive="bg-primary text-white"
+          (click)="closeSidebar()"
           class="nav-link flex items-center w-full h-12 px-4 text-[var(--text-color)] rounded-xl hover:bg-primary hover:text-white transition-colors duration-200"
         >
           <svg
@@ -189,6 +192,7 @@
         <a
           routerLink="/settings"
           routerLinkActive="bg-primary text-white"
+          (click)="closeSidebar()"
           class="nav-link flex items-center w-full h-12 px-4 text-[var(--text-color)] rounded-xl hover:bg-primary hover:text-white transition-colors duration-200"
         >
           <svg
@@ -216,7 +220,7 @@
 
       <div>
         <button
-          (click)="toggleTheme()"
+          (click)="toggleTheme(); closeSidebar()"
           class="nav-link flex items-center w-full h-12 px-4 text-[var(--text-color)] rounded-xl hover:bg-primary hover:text-white transition-colors duration-200"
         >
           <svg
@@ -239,7 +243,7 @@
 
       <div>
         <button
-          (click)="logout()"
+          (click)="logout(); closeSidebar()"
           class="nav-link flex items-center w-full h-12 px-4 text-[var(--text-color)] rounded-xl hover:bg-red-500 hover:text-white transition-colors duration-200"
         >
           <svg

--- a/src/app/components/layout-component/layout-component.scss
+++ b/src/app/components/layout-component/layout-component.scss
@@ -1,8 +1,17 @@
 /* Responsive styling handled with Tailwind utility classes. */
 
+aside {
+  transition: width 0.3s ease-in-out, padding 0.3s ease-in-out;
+}
+
+aside .logo-container,
+aside .nav-link {
+  transition: all 0.3s ease-in-out;
+}
+
 aside.collapsed {
   width: 5rem;
-  padding: 1rem;
+  padding: 1rem 0;
 }
 
 aside.collapsed .nav-text {
@@ -10,9 +19,7 @@ aside.collapsed .nav-text {
 }
 
 aside.collapsed .nav-link {
-  justify-content: center;
-  padding-left: 0;
-  padding-right: 0;
+  @apply justify-center w-12 h-12 p-0 mx-auto;
 }
 
 aside.collapsed .logo-container {
@@ -21,15 +28,13 @@ aside.collapsed .logo-container {
 
 @media (min-width: 768px) {
   aside.collapsed:hover {
-    width: max-content;
+    width: 16rem;
   }
   aside.collapsed:hover .nav-text {
     display: inline;
   }
   aside.collapsed:hover .nav-link {
-    justify-content: flex-start;
-    padding-left: 1rem;
-    padding-right: 1rem;
+    @apply w-full justify-start p-4 mx-0;
   }
   aside.collapsed:hover .logo-container {
     @apply justify-start bg-transparent px-4 h-12;

--- a/src/app/components/layout-component/layout-component.ts
+++ b/src/app/components/layout-component/layout-component.ts
@@ -1,9 +1,8 @@
-import { Component } from '@angular/core';
+import { Component, HostListener } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
+import { RouterLink, RouterLinkActive, RouterOutlet, NavigationEnd, Router } from '@angular/router';
 import { ToastContainerComponent } from '../toast-container-component/toast-container-component';
 import { AuthService } from '../../services/auth-service';
-import { Router } from '@angular/router';
 import { ThemeService } from '../../services/theme-service';
 
 @Component({
@@ -20,7 +19,13 @@ export class LayoutComponent {
     private authService: AuthService,
     private router: Router,
     private themeService: ThemeService
-  ) {}
+  ) {
+    this.router.events.subscribe(event => {
+      if (event instanceof NavigationEnd && window.innerWidth < 768) {
+        this.isSidebarOpen = false;
+      }
+    });
+  }
 
   logout() {
     this.authService.logout()
@@ -38,5 +43,16 @@ export class LayoutComponent {
 
   toggleCollapse() {
     this.isSidebarCollapsed = !this.isSidebarCollapsed;
+  }
+
+  closeSidebar() {
+    this.isSidebarOpen = false;
+  }
+
+  @HostListener('window:resize')
+  onResize() {
+    if (window.innerWidth >= 768) {
+      this.isSidebarOpen = false;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- make sidebar responsive for mobile and desktop
- automatically hide sidebar after navigation and resize

## Testing
- `npm run build`
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68a0efa294bc832786ce66f4c3752419