### PR TITLE
Ajustes de navbar y mejoras en historial y agenda

### DIFF
--- a/src/app/components/history-modal-component/history-modal-component.html
+++ b/src/app/components/history-modal-component/history-modal-component.html
@@ -11,14 +11,6 @@
 
     <div class="border-b border-gray-200">
       <nav class="-mb-px flex space-x-6" aria-label="Tabs">
-        <button (click)="selectTab('data')"
-                [ngClass]="{
-                  'border-primary text-primary': activeTab === 'data',
-                  'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300': activeTab !== 'data'
-                }"
-                class="whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm">
-          Historial de Datos
-        </button>
         <button *ngIf="showAppointmentHistoryTab"
                 (click)="selectTab('appointments')"
                 [ngClass]="{
@@ -27,6 +19,14 @@
                 }"
                 class="whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm">
           Historial de Citas
+        </button>
+        <button (click)="selectTab('data')"
+                [ngClass]="{
+                  'border-primary text-primary': activeTab === 'data',
+                  'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300': activeTab !== 'data'
+                }"
+                class="whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm">
+          Historial de Datos
         </button>
       </nav>
     </div>
@@ -61,7 +61,7 @@
                   'bg-blue-100 text-blue-800': apt.status === 'confirmed',
                   'bg-yellow-100 text-yellow-800': apt.status === 'pending',
                   'bg-red-100 text-red-800': apt.status === 'cancelled'
-                }">{{ apt.status | titlecase }}</span>
+                }">{{ translateStatus(apt.status) | titlecase }}</span>
               </div>
               <div *ngIf="apt.notes" class="mt-3 pt-3 border-t">
                 <h4 class="text-xs font-bold text-gray-500 uppercase">Notas</h4>

--- a/src/app/components/history-modal-component/history-modal-component.ts
+++ b/src/app/components/history-modal-component/history-modal-component.ts
@@ -16,12 +16,22 @@ export class HistoryModalComponent {
   @Input() showAppointmentHistoryTab = false; 
   @Output() onCancel = new EventEmitter<void>();
 
-  activeTab: 'data' | 'appointments' = 'data'; // La pestaña activa por defecto
+  activeTab: 'data' | 'appointments' = 'appointments'; // La pestaña activa por defecto
+
+  private statusLabels: Record<string, string> = {
+    confirmed: 'confirmada',
+    pending: 'pendiente',
+    cancelled: 'cancelada',
+  };
 
   constructor() {}
 
   selectTab(tab: 'data' | 'appointments'): void {
     this.activeTab = tab;
+  }
+
+  translateStatus(status: string): string {
+    return this.statusLabels[status] || status;
   }
 
   cancel(): void {

--- a/src/app/components/layout-component/layout-component.html
+++ b/src/app/components/layout-component/layout-component.html
@@ -14,7 +14,7 @@
       '-translate-x-full': !isSidebarOpen && isMobile,
       'collapsed': isSidebarCollapsed
     }"
-    class="fixed inset-y-0 left-0 z-40 flex flex-col items-start w-64 h-screen p-4 space-y-8 bg-[var(--card-bg)] shadow-md overflow-y-auto transition-transform duration-300 md:relative group"
+    class="fixed inset-y-0 left-0 z-40 flex flex-col items-start w-56 h-screen p-4 space-y-8 bg-[var(--card-bg)] shadow-md overflow-y-auto transition-transform duration-300 md:relative group"
   >
     <!-- Logo y controles de tamaño -->
     <div

--- a/src/app/components/layout-component/layout-component.scss
+++ b/src/app/components/layout-component/layout-component.scss
@@ -19,7 +19,7 @@ aside.collapsed .nav-text {
 }
 
 aside.collapsed .nav-link {
-  @apply justify-center w-10 h-10 p-0 mx-auto;
+  @apply justify-start w-full h-10 p-0 pl-2 mx-0;
 }
 
 aside.collapsed .logo-container {
@@ -38,7 +38,7 @@ aside:not(.collapsed) .nav-link {
 
 @media (min-width: 768px) {
   aside.collapsed:hover {
-    width: 16rem;
+    width: 14rem;
   }
   aside.collapsed:hover nav {
     @apply items-start;

--- a/src/app/pages/agenda-component/agenda-component.ts
+++ b/src/app/pages/agenda-component/agenda-component.ts
@@ -199,8 +199,11 @@ export class AgendaComponent implements OnInit, OnDestroy {
   // --- Manejadores de Eventos del Calendario ---
 
   onHourSegmentClicked(event: { date: Date }): void {
-    this.selectedDate = event.date;
+    this.selectedAppointment = null;
+    this.selectedTimeBlock = null;
+    this.selectedDate = new Date(event.date);
     this.showChoiceModal = true;
+    this.cdr.markForCheck();
   }
 
   handleEventClicked({ event }: { event: CalendarEvent<any> }): void {
@@ -218,8 +221,10 @@ export class AgendaComponent implements OnInit, OnDestroy {
   // --- Manejadores de Acciones de los Modales ---
 
   openAppointmentForm(): void {
+    this.selectedAppointment = null;
     this.showChoiceModal = false;
     this.showAppointmentModal = true;
+    this.cdr.markForCheck();
   }
 
   openTimeBlockForm(): void {


### PR DESCRIPTION
## Resumen
- Reducir ancho del navbar y alinear iconos al minimizar
- Reordenar pestañas del historial de clientes y traducir estados de citas
- Usar fecha y hora seleccionadas al crear citas desde el calendario

## Pruebas
- `CHROME_BIN=$(which chromium-browser) npm test -- --watch=false` *(falló: requiere instalar snap para Chromium)*


------
https://chatgpt.com/codex/tasks/task_e_68a2554b06b88327b38be2ff791b552c