### PR TITLE
Add non-work periods to agenda calendar

### DIFF
--- a/src/app/pages/agenda-component/agenda-component.scss
+++ b/src/app/pages/agenda-component/agenda-component.scss
@@ -21,6 +21,6 @@
 }
 
 ::ng-deep .cal-non-work {
-  background: #f0f0f0 !important;
-  color: #666 !important;
+  background: #e6e0ff !important;
+  color: #5a4a8f !important;
 }

--- a/src/app/pages/agenda-component/agenda-component.ts
+++ b/src/app/pages/agenda-component/agenda-component.ts
@@ -130,14 +130,17 @@ export class AgendaComponent implements OnInit, OnDestroy {
             const daySchedule = schedule[dayName];
 
             const dayStart = setMinutes(setHours(dateInWeek, this.dayStartHour), 0);
-            const dayEnd = setMinutes(setHours(dateInWeek, this.dayEndHour), 0);
+            const dayEnd = setMinutes(
+              setHours(dateInWeek, Math.min(24, this.dayEndHour + 1)),
+              0
+            );
 
             if (!daySchedule || !daySchedule.isActive || !daySchedule.workHours) {
               nonWorkEvents.push({
                 start: dayStart,
                 end: dayEnd,
                 title: '<i>No laborable</i>',
-                color: { primary: '#f0f0f0', secondary: '#f0f0f0' },
+                color: { primary: '#e6e0ff', secondary: '#e6e0ff' },
                 cssClass: 'cal-non-work',
                 draggable: false,
                 resizable: { beforeStart: false, afterEnd: false },
@@ -156,7 +159,7 @@ export class AgendaComponent implements OnInit, OnDestroy {
                 start: dayStart,
                 end: workStart,
                 title: '<i>No laborable</i>',
-                color: { primary: '#f0f0f0', secondary: '#f0f0f0' },
+                color: { primary: '#e6e0ff', secondary: '#e6e0ff' },
                 cssClass: 'cal-non-work',
                 draggable: false,
                 resizable: { beforeStart: false, afterEnd: false },
@@ -169,7 +172,7 @@ export class AgendaComponent implements OnInit, OnDestroy {
                 start: workEnd,
                 end: dayEnd,
                 title: '<i>No laborable</i>',
-                color: { primary: '#f0f0f0', secondary: '#f0f0f0' },
+                color: { primary: '#e6e0ff', secondary: '#e6e0ff' },
                 cssClass: 'cal-non-work',
                 draggable: false,
                 resizable: { beforeStart: false, afterEnd: false },


### PR DESCRIPTION
## Summary
- show "No laborable" events before/after working hours and on inactive days
- gray styling for non-work events and ignore clicks

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68a2aa615fb08327883ee349e98667d9