### PR TITLE
feat: add colors to appointment modal

### DIFF
--- a/src/app/components/day-appointments-modal-component/day-appointments-modal-component.html
+++ b/src/app/components/day-appointments-modal-component/day-appointments-modal-component.html
@@ -11,7 +11,7 @@
           </p>
           <p class="text-xs flex gap-1 items-center" *ngIf="event.meta?.eventType === 'appointment'">
             <span [ngClass]="getTypeClass(event.meta.type)">
-              {{ event.meta.type === 'online' ? 'Online' : 'Presencial' }}
+              {{ event.meta.type?.toLowerCase() === 'online' ? 'Online' : 'Presencial' }}
             </span>
             <span [ngClass]="getStatusClass(event.meta.status)">
               {{ getStatusLabel(event.meta.status) }}

--- a/src/app/components/day-appointments-modal-component/day-appointments-modal-component.ts
+++ b/src/app/components/day-appointments-modal-component/day-appointments-modal-component.ts
@@ -13,7 +13,7 @@ export class DayAppointmentsModalComponent {
   @Input() events: CalendarEvent[] = [];
   @Output() onClose = new EventEmitter<void>();
 
-  private readonly statusTranslations: Record<string, string> = {
+  private readonly statusLabels: Record<string, string> = {
     confirmed: 'Confirmada',
     pending: 'Pendiente',
     cancelled: 'Cancelada',
@@ -30,19 +30,39 @@ export class DayAppointmentsModalComponent {
     presencial: 'bg-green-100 text-green-800',
   };
 
+  private normalizeStatus(status: string = ''): string {
+    switch (status.toLowerCase()) {
+      case 'confirmada':
+      case 'confirmed':
+        return 'confirmed';
+      case 'pendiente':
+      case 'pending':
+        return 'pending';
+      case 'cancelada':
+      case 'canceled':
+      case 'cancelled':
+        return 'cancelled';
+      default:
+        return status.toLowerCase();
+    }
+  }
+
   close(): void {
     this.onClose.emit();
   }
 
-  getStatusLabel(status: string): string {
-    return this.statusTranslations[status] || status;
+  getStatusLabel(status: string = ''): string {
+    const key = this.normalizeStatus(status);
+    return this.statusLabels[key] || status;
   }
 
-  getStatusClass(status: string): string {
-    return `px-2 py-0.5 rounded ${this.statusClasses[status] || 'bg-gray-100 text-gray-800'}`;
+  getStatusClass(status: string = ''): string {
+    const key = this.normalizeStatus(status);
+    return `px-2 py-0.5 rounded ${this.statusClasses[key] || 'bg-gray-100 text-gray-800'}`;
   }
 
-  getTypeClass(type: string): string {
-    return `px-2 py-0.5 rounded ${this.typeClasses[type] || 'bg-gray-100 text-gray-800'}`;
+  getTypeClass(type: string = ''): string {
+    const key = type.toLowerCase();
+    return `px-2 py-0.5 rounded ${this.typeClasses[key] || 'bg-gray-100 text-gray-800'}`;
   }
 }


### PR DESCRIPTION
## Summary
- color-coded labels for appointment type and status in calendar modal
- display appointment status in Spanish

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68a389c0f7108327881412d1e801d72a