### PR TITLE
fix: update tag colors for appointment status and type

### DIFF
--- a/src/app/components/day-appointments-modal-component/day-appointments-modal-component.ts
+++ b/src/app/components/day-appointments-modal-component/day-appointments-modal-component.ts
@@ -20,14 +20,14 @@ export class DayAppointmentsModalComponent {
   };
 
   private readonly statusClasses: Record<string, string> = {
-    confirmed: 'bg-blue-500 text-white',
-    pending: 'bg-yellow-500 text-white',
-    cancelled: 'bg-red-500 text-white',
+    confirmed: 'bg-blue-100 text-blue-800',
+    pending: 'bg-[#FEF9C3] text-[#884E0F]',
+    cancelled: 'bg-red-100 text-red-800',
   };
 
   private readonly typeClasses: Record<string, string> = {
-    online: 'bg-purple-500 text-white',
-    presencial: 'bg-green-500 text-white',
+    online: 'bg-purple-100 text-purple-800',
+    presencial: 'bg-[#DCFCE7] text-[#166536]',
   };
 
   private normalizeStatus(status: string = ''): string {


### PR DESCRIPTION
## Summary
- adjust modal tag colors for appointment status and type

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a399d5a2988327bf6b51f0ea15e891