### PR TITLE
fix: improve toast close button dark mode styles

### DIFF
--- a/src/app/components/dashboard-component/dashboard-component.html
+++ b/src/app/components/dashboard-component/dashboard-component.html
@@ -3,15 +3,15 @@
     class="flex flex-col md:flex-row items-start md:items-center justify-between gap-4"
   >
     <div>
-      <h1 class="text-3xl font-bold text-gray-800">Dashboard</h1>
-      <p class="mt-1 text-gray-600">
+      <h1 class="text-3xl font-bold text-gray-800 dark:text-gray-200">Dashboard</h1>
+      <p class="mt-1 text-gray-600 dark:text-gray-400">
         Bienvenido, aquí tienes un resumen de tu actividad.
       </p>
     </div>
     <div class="flex items-center space-x-2">
       <button
         (click)="openNewBlockModal()"
-        class="px-4 py-2 font-semibold text-gray-700 bg-white border border-gray-300 rounded-lg shadow-sm hover:bg-gray-50 dark:text-gray-200 dark:bg-gray-700 dark:border-gray-600 dark:hover:bg-gray-600"
+        class="px-4 py-2 font-semibold text-gray-700 bg-white border border-gray-300 rounded-lg shadow-sm hover:bg-gray-50 dark:text-gray-200 dark:bg-gray-700 dark:border-gray-600 dark:hover:bg-gray-700"
       >
         Bloquear Horario
       </button>
@@ -34,8 +34,8 @@
       }"
     >
       <div>
-        <span class="text-sm font-medium text-gray-500">Citas para Hoy</span>
-        <p class="text-3xl font-bold text-gray-800">
+        <span class="text-sm font-medium text-gray-500 dark:text-gray-400">Citas para Hoy</span>
+        <p class="text-3xl font-bold text-gray-800 dark:text-gray-200">
           {{ (upcomingAppointments$ | async)?.length || 0 }}
         </p>
       </div>
@@ -63,7 +63,7 @@
       }"
     >
       <div>
-        <span class="text-sm font-medium text-gray-500">Citas Pendientes</span>
+        <span class="text-sm font-medium text-gray-500 dark:text-gray-400">Citas Pendientes</span>
         <p class="text-3xl font-bold text-yellow-500">
           {{ (pendingMonthAppointments$ | async)?.length || 0 }}
         </p>
@@ -92,7 +92,7 @@
       }"
     >
       <div>
-        <span class="text-sm font-medium text-gray-500">Citas Canceladas</span>
+        <span class="text-sm font-medium text-gray-500 dark:text-gray-400">Citas Canceladas</span>
         <p class="text-3xl font-bold text-red-500">
           {{ cancelledAppointments.length }}
         </p>
@@ -118,8 +118,8 @@
       routerLink="/clients"
     >
       <div>
-        <span class="text-sm font-medium text-gray-500">Total de Clientes</span>
-        <p class="text-3xl font-bold text-gray-800">{{ stats.totalClients }}</p>
+        <span class="text-sm font-medium text-gray-500 dark:text-gray-400">Total de Clientes</span>
+        <p class="text-3xl font-bold text-gray-800 dark:text-gray-200">{{ stats.totalClients }}</p>
       </div>
       <div class="p-3 rounded-full bg-green-100 text-green-500">
         <svg
@@ -142,10 +142,10 @@
       routerLink="/services"
     >
       <div>
-        <span class="text-sm font-medium text-gray-500"
+        <span class="text-sm font-medium text-gray-500 dark:text-gray-400"
           >Servicios Ofrecidos</span
         >
-        <p class="text-3xl font-bold text-gray-800">
+        <p class="text-3xl font-bold text-gray-800 dark:text-gray-200">
           {{ stats.totalServices }}
         </p>
       </div>
@@ -201,7 +201,7 @@
           Mes
         </button>
       </div>
-      <div class="ml-auto text-sm text-gray-600">
+      <div class="ml-auto text-sm text-gray-600 dark:text-gray-400">
         <ng-container [ngSwitch]="activeView">
           <span *ngSwitchCase="'day'"
             >{{ (upcomingAppointments$ | async)?.length || 0 }} citas</span
@@ -229,7 +229,7 @@
           <div *ngIf="appointments.length > 0; else emptyDay" class="space-y-4">
             <div
               *ngFor="let apt of appointments"
-              class="flex flex-col sm:flex-row sm:items-center sm:justify-between p-4 border rounded-lg gap-2 cursor-pointer hover:bg-gray-50"
+              class="flex flex-col sm:flex-row sm:items-center sm:justify-between p-4 border rounded-lg gap-2 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700"
               (click)="openEditAppointment(apt)"
             >
               <div
@@ -241,7 +241,7 @@
                       apt.start.toDate() | date: "EEE dd/MM" : undefined : "es"
                     }}
                   </p>
-                  <p class="text-xs text-gray-500">
+                  <p class="text-xs text-gray-500 dark:text-gray-400">
                     {{
                       apt.start.toDate() | date: "shortTime" : undefined : "es"
                     }}
@@ -252,8 +252,8 @@
                   </p>
                 </div>
                 <div class="text-center sm:text-left">
-                  <h3 class="font-semibold text-gray-800">{{ apt.title }}</h3>
-                  <p class="text-sm text-gray-500">
+                  <h3 class="font-semibold text-gray-800 dark:text-gray-200">{{ apt.title }}</h3>
+                  <p class="text-sm text-gray-500 dark:text-gray-400">
                     {{ clientsMap.get(apt.clientId) || "Cliente Desconocido" }}
                   </p>
                 </div>
@@ -281,7 +281,7 @@
             </div>
           </div>
           <ng-template #emptyDay
-            ><p class="text-center text-gray-500">
+            ><p class="text-center text-gray-500 dark:text-gray-400">
               No tienes citas programadas para hoy.
             </p></ng-template
           >
@@ -298,7 +298,7 @@
           >
             <div
               *ngFor="let apt of appointments"
-              class="flex flex-col sm:flex-row sm:items-center sm:justify-between p-4 border rounded-lg gap-2 cursor-pointer hover:bg-gray-50"
+              class="flex flex-col sm:flex-row sm:items-center sm:justify-between p-4 border rounded-lg gap-2 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700"
               (click)="openEditAppointment(apt)"
             >
               <div
@@ -310,7 +310,7 @@
                       apt.start.toDate() | date: "EEE dd/MM" : undefined : "es"
                     }}
                   </p>
-                  <p class="text-xs text-gray-500">
+                  <p class="text-xs text-gray-500 dark:text-gray-400">
                     {{
                       apt.start.toDate() | date: "shortTime" : undefined : "es"
                     }}
@@ -321,8 +321,8 @@
                   </p>
                 </div>
                 <div class="text-center sm:text-left">
-                  <h3 class="font-semibold text-gray-800">{{ apt.title }}</h3>
-                  <p class="text-sm text-gray-500">
+                  <h3 class="font-semibold text-gray-800 dark:text-gray-200">{{ apt.title }}</h3>
+                  <p class="text-sm text-gray-500 dark:text-gray-400">
                     {{ clientsMap.get(apt.clientId) || "Cliente Desconocido" }}
                   </p>
                 </div>
@@ -350,7 +350,7 @@
             </div>
           </div>
           <ng-template #emptyWeek
-            ><p class="text-center text-gray-500">
+            ><p class="text-center text-gray-500 dark:text-gray-400">
               No tienes citas programadas esta semana.
             </p></ng-template
           >
@@ -367,7 +367,7 @@
           >
             <div
               *ngFor="let apt of appointments"
-              class="flex flex-col sm:flex-row sm:items-center sm:justify-between p-4 border rounded-lg gap-2 cursor-pointer hover:bg-gray-50"
+              class="flex flex-col sm:flex-row sm:items-center sm:justify-between p-4 border rounded-lg gap-2 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700"
               (click)="openEditAppointment(apt)"
             >
               <div
@@ -379,7 +379,7 @@
                       apt.start.toDate() | date: "EEE dd/MM" : undefined : "es"
                     }}
                   </p>
-                  <p class="text-xs text-gray-500">
+                  <p class="text-xs text-gray-500 dark:text-gray-400">
                     {{
                       apt.start.toDate() | date: "shortTime" : undefined : "es"
                     }}
@@ -390,8 +390,8 @@
                   </p>
                 </div>
                 <div class="text-center sm:text-left">
-                  <h3 class="font-semibold text-gray-800">{{ apt.title }}</h3>
-                  <p class="text-sm text-gray-500">
+                  <h3 class="font-semibold text-gray-800 dark:text-gray-200">{{ apt.title }}</h3>
+                  <p class="text-sm text-gray-500 dark:text-gray-400">
                     {{ clientsMap.get(apt.clientId) || "Cliente Desconocido" }}
                   </p>
                 </div>
@@ -419,7 +419,7 @@
             </div>
           </div>
           <ng-template #emptyMonth
-            ><p class="text-center text-gray-500">
+            ><p class="text-center text-gray-500 dark:text-gray-400">
               No tienes citas programadas este mes.
             </p></ng-template
           >
@@ -439,7 +439,7 @@
           >
             <div
               *ngFor="let apt of appointments"
-              class="flex flex-col sm:flex-row sm:items-center sm:justify-between p-4 border rounded-lg gap-2 cursor-pointer hover:bg-gray-50"
+              class="flex flex-col sm:flex-row sm:items-center sm:justify-between p-4 border rounded-lg gap-2 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700"
               (click)="openEditAppointment(apt)"
             >
               <div
@@ -451,7 +451,7 @@
                       apt.start.toDate() | date: "EEE dd/MM" : undefined : "es"
                     }}
                   </p>
-                  <p class="text-xs text-gray-500">
+                  <p class="text-xs text-gray-500 dark:text-gray-400">
                     {{
                       apt.start.toDate() | date: "shortTime" : undefined : "es"
                     }}
@@ -462,8 +462,8 @@
                   </p>
                 </div>
                 <div class="text-center sm:text-left">
-                  <h3 class="font-semibold text-gray-800">{{ apt.title }}</h3>
-                  <p class="text-sm text-gray-500">
+                  <h3 class="font-semibold text-gray-800 dark:text-gray-200">{{ apt.title }}</h3>
+                  <p class="text-sm text-gray-500 dark:text-gray-400">
                     {{ clientsMap.get(apt.clientId) || "Cliente Desconocido" }}
                   </p>
                 </div>
@@ -485,7 +485,7 @@
             </div>
           </div>
         <ng-template #emptyPending
-          ><p class="text-center text-gray-500">
+          ><p class="text-center text-gray-500 dark:text-gray-400">
             No tienes citas pendientes este mes.
           </p></ng-template
         >
@@ -499,7 +499,7 @@
         >
           <div
             *ngFor="let apt of cancelledAppointments"
-            class="flex flex-col sm:flex-row sm:items-center sm:justify-between p-4 border rounded-lg gap-2 cursor-pointer hover:bg-gray-50"
+            class="flex flex-col sm:flex-row sm:items-center sm:justify-between p-4 border rounded-lg gap-2 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700"
             (click)="openEditAppointment(apt)"
           >
             <div
@@ -509,15 +509,15 @@
                 <p class="font-bold text-primary">
                   {{ apt.start.toDate() | date: "EEE dd/MM" : undefined : "es" }}
                 </p>
-                <p class="text-xs text-gray-500">
+                <p class="text-xs text-gray-500 dark:text-gray-400">
                   {{ apt.start.toDate() | date: "shortTime" : undefined : "es" }}
                   -
                   {{ apt.end.toDate() | date: "shortTime" : undefined : "es" }}
                 </p>
               </div>
               <div class="text-center sm:text-left">
-                <h3 class="font-semibold text-gray-800">{{ apt.title }}</h3>
-                <p class="text-sm text-gray-500">
+                <h3 class="font-semibold text-gray-800 dark:text-gray-200">{{ apt.title }}</h3>
+                <p class="text-sm text-gray-500 dark:text-gray-400">
                   {{ clientsMap.get(apt.clientId) || "Cliente Desconocido" }}
                 </p>
               </div>
@@ -539,14 +539,14 @@
           </div>
         </div>
         <ng-template #emptyCancelled>
-          <p class="text-center text-gray-500">
+          <p class="text-center text-gray-500 dark:text-gray-400">
             No tienes citas canceladas próximas.
           </p>
         </ng-template>
       </ng-container>
 
       <ng-template #loading
-        ><p class="text-gray-500">Cargando citas...</p></ng-template
+        ><p class="text-gray-500 dark:text-gray-400">Cargando citas...</p></ng-template
       >
     </div>
   </div>

--- a/src/app/components/history-modal-component/history-modal-component.html
+++ b/src/app/components/history-modal-component/history-modal-component.html
@@ -53,11 +53,11 @@
           <div *ngIf="appointments.length > 0; else emptyAppointments" class="space-y-4">
             <div *ngFor="let apt of appointments"
                  (click)="openAppointmentDetail(apt)"
-                 class="p-4 border rounded-lg cursor-pointer transition-colors hover:bg-gray-50">
+                 class="p-4 border border-gray-200 dark:border-gray-700 rounded-lg cursor-pointer transition-colors hover:bg-gray-50 dark:hover:bg-gray-700">
               <div class="flex justify-between items-start">
                 <div>
-                  <h3 class="font-semibold text-gray-800">{{ apt.title }}</h3>
-                  <p class="text-sm text-gray-500">{{ apt.start.toDate() | date:'fullDate' }}</p>
+                  <h3 class="font-semibold text-gray-800 dark:text-gray-200">{{ apt.title }}</h3>
+                  <p class="text-sm text-gray-500 dark:text-gray-400">{{ apt.start.toDate() | date:'fullDate' }}</p>
                 </div>
                 <span class="px-2 py-1 text-xs font-semibold rounded-full" [ngClass]="{
                   'bg-blue-100 text-blue-800': apt.status === 'confirmed',
@@ -65,9 +65,9 @@
                   'bg-red-100 text-red-800': apt.status === 'cancelled'
                 }">{{ translateStatus(apt.status) | titlecase }}</span>
               </div>
-              <div *ngIf="apt.notes" class="mt-3 pt-3 border-t">
-                <h4 class="text-xs font-bold text-gray-500 uppercase">Notas</h4>
-                <p class="text-sm text-gray-700 whitespace-pre-wrap">{{ apt.notes }}</p>
+              <div *ngIf="apt.notes" class="mt-3 pt-3 border-t border-gray-200 dark:border-gray-700">
+                <h4 class="text-xs font-bold text-gray-500 dark:text-gray-400 uppercase">Notas</h4>
+                <p class="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap">{{ apt.notes }}</p>
               </div>
             </div>
           </div>

--- a/src/app/components/toast-component/toast-component.html
+++ b/src/app/components/toast-component/toast-component.html
@@ -18,10 +18,10 @@
   <div class="ml-3 text-sm font-normal mr-4">{{ toast.message }}</div>
   
   <button 
-    (click)="remove()" 
-    type="button" 
-    class="ml-auto -mx-1.5 -my-1.5 p-1.5 inline-flex h-8 w-8 rounded-lg hover:bg-white hover:bg-opacity-20 focus:ring-2 focus:ring-gray-300"
+    (click)="remove()"
+    type="button"
+    class="ml-auto -mx-1.5 -my-1.5 p-1.5 inline-flex h-8 w-8 rounded-lg text-white hover:text-gray-900 dark:text-white dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-700 focus:ring-2 focus:ring-gray-300"
     aria-label="Close">
-    <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"></path></svg>
+  <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"></path></svg>
   </button>
 </div>

--- a/src/app/pages/clients-component/clients-component.html
+++ b/src/app/pages/clients-component/clients-component.html
@@ -36,7 +36,7 @@
           [(ngModel)]="searchTerm"
           (ngModelChange)="searchTerm$.next($event)"
           placeholder="Buscar por nombre o correo"
-          class="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg"
+          class="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400"
         />
       </div>
       <button (click)="openClientModal()" class="px-4 py-2 font-semibold text-white rounded-lg shadow-md bg-primary hover:bg-opacity-90">

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -75,6 +75,16 @@ table {
   background-color: var(--card-bg) !important;
 }
 
+.dark-theme .hover\:bg-white:hover,
+.dark-theme .hover\:bg-gray-50:hover,
+.dark-theme .hover\:bg-gray-100:hover,
+.dark-theme .hover\:bg-gray-200:hover,
+.dark-theme .hover\:bg-gray-300:hover,
+.dark-theme .hover\:bg-gray-400:hover,
+.dark-theme .hover\:bg-gray-500:hover {
+  background-color: var(--card-bg) !important;
+}
+
 .dark-theme .text-gray-900,
 .dark-theme .text-gray-800,
 .dark-theme .text-gray-700,

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -66,6 +66,19 @@ table {
   color: var(--text-color) !important;
 }
 
+.dark-theme .cal-month-view,
+.dark-theme .cal-cell,
+.dark-theme .cal-day-cell {
+  background-color: var(--calendar-bg) !important;
+  color: var(--text-color) !important;
+}
+
+.dark-theme .cal-day-cell.cal-today,
+.dark-theme .cal-day-badge {
+  background-color: var(--hover-bg) !important;
+  color: var(--text-color) !important;
+}
+
 .dark-theme .bg-white,
 .dark-theme .bg-gray-50,
 .dark-theme .bg-gray-100,
@@ -109,7 +122,7 @@ table {
 }
 
 .cal-event {
-  color: #000 !important;
+  color: var(--text-color) !important;
 }
 
 .client-avatar {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -121,8 +121,13 @@ table {
   border-color: var(--border-color) !important;
 }
 
-.cal-event {
+.dark-theme .cal-month-view .cal-event {
   color: var(--text-color) !important;
+}
+
+.dark-theme .cal-week-view .cal-event,
+.dark-theme .cal-day-view .cal-event {
+  color: #1f2937 !important;
 }
 
 .client-avatar {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -25,6 +25,7 @@
   --calendar-bg: #1f2937;
   --input-bg: #1f2937;
   --border-color: #374151;
+  --hover-bg: #374151; /* Tailwind gray-700 */
 }
 
 body {
@@ -82,7 +83,7 @@ table {
 .dark-theme .hover\:bg-gray-300:hover,
 .dark-theme .hover\:bg-gray-400:hover,
 .dark-theme .hover\:bg-gray-500:hover {
-  background-color: var(--card-bg) !important;
+  background-color: var(--hover-bg) !important;
 }
 
 .dark-theme .text-gray-900,


### PR DESCRIPTION
## Summary
- enhance toast close button hover styles with Tailwind dark mode support
- keep icon legible across themes by enforcing text contrast

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Cannot find module '@angular-devkit/build-angular/plugins/karma')*

------
https://chatgpt.com/codex/tasks/task_e_68adbb0168888327a9bd2c48a43d7503