### PR TITLE
Add client portal link to dashboard

### DIFF
--- a/src/app/components/dashboard-component/dashboard-component.html
+++ b/src/app/components/dashboard-component/dashboard-component.html
@@ -21,6 +21,14 @@
       >
         + Agendar Cita
       </button>
+      <a
+        [href]="clientPortalUrl"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="px-4 py-2 font-semibold text-gray-700 bg-white border border-gray-300 rounded-lg shadow-sm hover:bg-gray-50 dark:text-gray-200 dark:bg-gray-700 dark:border-gray-600 dark:hover:bg-gray-700"
+      >
+        Portal Clientes
+      </a>
     </div>
   </div>
 

--- a/src/app/components/dashboard-component/dashboard-component.html
+++ b/src/app/components/dashboard-component/dashboard-component.html
@@ -25,7 +25,7 @@
         [href]="clientPortalUrl"
         target="_blank"
         rel="noopener noreferrer"
-        class="px-4 py-2 font-semibold text-gray-700 bg-white border border-gray-300 rounded-lg shadow-sm hover:bg-gray-50 dark:text-gray-200 dark:bg-gray-700 dark:border-gray-600 dark:hover:bg-gray-700"
+        class="hidden md:inline-block px-4 py-2 font-semibold text-gray-700 bg-white border border-gray-300 rounded-lg shadow-sm hover:bg-gray-50 dark:text-gray-200 dark:bg-gray-700 dark:border-gray-600 dark:hover:bg-gray-700"
       >
         Portal Clientes
       </a>

--- a/src/app/components/dashboard-component/dashboard-component.ts
+++ b/src/app/components/dashboard-component/dashboard-component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { Observable, combineLatest } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { Auth, authState } from '@angular/fire/auth';
 import {
   startOfDay,
   endOfDay,
@@ -49,6 +50,8 @@ export class DashboardComponent implements OnInit {
     pendingAppointments: 0,
   };
 
+  clientPortalUrl: string | null = null;
+
   private statusLabels: Record<Appointment['status'], string> = {
     confirmed: 'Confirmada',
     pending: 'Pendiente',
@@ -72,10 +75,16 @@ export class DashboardComponent implements OnInit {
     private timeBlockService: TimeBlockService,
     private toastService: ToastService,
     private cdr: ChangeDetectorRef,
+    private auth: Auth,
   ) {}
 
   ngOnInit(): void {
     this.loadDashboardData();
+    authState(this.auth).subscribe((user) => {
+      this.clientPortalUrl = user
+        ? `https://gestion-agenda-cliente.web.app/agendar/${user.uid}`
+        : null;
+    });
   }
 
   loadDashboardData(): void {

--- a/src/app/components/layout-component/layout-component.html
+++ b/src/app/components/layout-component/layout-component.html
@@ -287,22 +287,35 @@
     <header
       class="flex items-center justify-between p-4 bg-[var(--card-bg)] shadow-md md:hidden"
     >
-      <button (click)="toggleSidebar()" class="p-2 text-[var(--text-color)]">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          class="w-6 h-6"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
+      <div class="flex items-center gap-2">
+        <button (click)="toggleSidebar()" class="p-2 text-[var(--text-color)]">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="w-6 h-6"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M4 6h16M4 12h16M4 18h16"
+            />
+          </svg>
+        </button>
+        <a
+          [href]="clientPortalUrl"
+          target="_blank"
+          rel="noopener noreferrer"
+          title="Portal Clientes"
+          class="p-2 text-[var(--text-color)] rounded-md hover:bg-gray-100 dark:hover:bg-gray-700"
         >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M4 6h16M4 12h16M4 18h16"
-          />
-        </svg>
-      </button>
+          <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h6m0 0v6m0-6L10 16M5 7a2 2 0 00-2 2v9a2 2 0 002 2h9a2 2 0 002-2v-3" />
+          </svg>
+        </a>
+      </div>
       <a
         routerLink="/dashboard"
         class="flex items-center justify-center w-6 h-6 text-white rounded-lg bg-primary"

--- a/src/app/components/layout-component/layout-component.ts
+++ b/src/app/components/layout-component/layout-component.ts
@@ -1,9 +1,10 @@
-import { Component, HostListener } from '@angular/core';
+import { Component, HostListener, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterLink, RouterLinkActive, RouterOutlet, NavigationEnd, Router } from '@angular/router';
 import { ToastContainerComponent } from '../toast-container-component/toast-container-component';
 import { AuthService } from '../../services/auth-service';
 import { ThemeService } from '../../services/theme-service';
+import { Auth, authState } from '@angular/fire/auth';
 
 @Component({
   selector: 'app-layout',
@@ -12,19 +13,29 @@ import { ThemeService } from '../../services/theme-service';
   templateUrl: './layout-component.html',
   styleUrls: ['./layout-component.scss']
 })
-export class LayoutComponent {
+export class LayoutComponent implements OnInit {
   isSidebarOpen = false;
   isSidebarCollapsed = false;
   isMobile = window.innerWidth < 768;
+  clientPortalUrl: string | null = null;
   constructor(
     private authService: AuthService,
     private router: Router,
-    private themeService: ThemeService
+    private themeService: ThemeService,
+    private auth: Auth
   ) {
     this.router.events.subscribe(event => {
       if (event instanceof NavigationEnd && this.isMobile) {
         this.isSidebarOpen = false;
       }
+    });
+  }
+
+  ngOnInit(): void {
+    authState(this.auth).subscribe((user) => {
+      this.clientPortalUrl = user
+        ? `https://gestion-agenda-cliente.web.app/agendar/${user.uid}`
+        : null;
     });
   }
 

--- a/src/app/pages/team-management-component/team-management-component.html
+++ b/src/app/pages/team-management-component/team-management-component.html
@@ -62,6 +62,14 @@
               <p class="text-sm text-gray-500">{{ member.email }}</p>
             </div>
             <div class="flex items-center gap-4">
+              <a
+                [href]="'https://gestion-agenda-cliente.web.app/agendar/' + member.id"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="px-4 py-2 font-semibold text-gray-700 bg-white border border-gray-300 rounded-lg shadow-sm hover:bg-gray-50 dark:text-gray-200 dark:bg-gray-700 dark:border-gray-600 dark:hover:bg-gray-700"
+              >
+                Portal Clientes
+              </a>
               <button (click)="openEditModal(member)" title="Editar" class="p-2 text-gray-500 dark:text-gray-300 rounded-md bg-transparent hover:bg-gray-100 dark:hover:!bg-gray-700">
                 <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.5L15.232 5.232z"></path></svg>
               </button>

--- a/src/app/pages/team-management-component/team-management-component.html
+++ b/src/app/pages/team-management-component/team-management-component.html
@@ -62,14 +62,17 @@
               <p class="text-sm text-gray-500">{{ member.email }}</p>
             </div>
             <div class="flex items-center gap-4">
-              <a
-                [href]="'https://gestion-agenda-cliente.web.app/agendar/' + member.id"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="px-4 py-2 font-semibold text-gray-700 bg-white border border-gray-300 rounded-lg shadow-sm hover:bg-gray-50 dark:text-gray-200 dark:bg-gray-700 dark:border-gray-600 dark:hover:bg-gray-700"
-              >
-                Portal Clientes
-              </a>
+                <a
+                  [href]="'https://gestion-agenda-cliente.web.app/agendar/' + member.id"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  title="Portal Clientes"
+                  class="p-2 text-gray-500 dark:text-gray-300 rounded-md bg-transparent hover:bg-gray-100 dark:hover:!bg-gray-700"
+                >
+                  <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h6m0 0v6m0-6L10 16M5 7a2 2 0 00-2 2v9a2 2 0 002 2h9a2 2 0 002-2v-3" />
+                  </svg>
+                </a>
               <button (click)="openEditModal(member)" title="Editar" class="p-2 text-gray-500 dark:text-gray-300 rounded-md bg-transparent hover:bg-gray-100 dark:hover:!bg-gray-700">
                 <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.5L15.232 5.232z"></path></svg>
               </button>


### PR DESCRIPTION
## Summary
- add link to client portal in dashboard
- build client portal URL with logged-in professional ID
- allow sharing client portal link per team member in team settings

## Testing
- `npm test -- --watch=false` (fails: Cannot find module '@angular-devkit/build-angular/plugins/karma')


------
https://chatgpt.com/codex/tasks/task_e_68b317b8b7f08327a3fbf4c768d1dc44